### PR TITLE
feature/frontend/lamduan-flowers

### DIFF
--- a/backend/app/src/module/lamduan-flowers/controller/lamduan-flowers.controller.ts
+++ b/backend/app/src/module/lamduan-flowers/controller/lamduan-flowers.controller.ts
@@ -31,19 +31,19 @@ export class LamduanFlowersController {
   }
 
   @Get()
-  @Permissions('lamduan-flow:read')
+  @Permissions('lamduan-flowers:read')
   findAll(@Query() query: Record<string, string>) {
     return this.lamduanFlowersService.findAll(query);
   }
 
   @Get(':id')
-  @Permissions('lamduan-flow:read:id')
+  @Permissions('lamduan-flowers:read:id')
   findOne(@Param('id') id: string) {
     return this.lamduanFlowersService.findOne(id);
   }
 
   @Patch(':id')
-  @Permissions('lamduan-flow:update')
+  @Permissions('lamduan-flowers:update')
   @UseInterceptors(new MultipartInterceptor(500))
   update(@Param('id') id: string, @Req() req: FastifyRequest) {
     const dto = req.body as UpdateLamduanFlowerDto;
@@ -51,7 +51,7 @@ export class LamduanFlowersController {
   }
 
   @Delete(':id')
-  @Permissions('lamduan-flow:delete')
+  @Permissions('lamduan-flowers:delete')
   remove(@Param('id') id: string) {
     return this.lamduanFlowersService.remove(id);
   }

--- a/frontend/admin/hooks/useLamduanFlowers.ts
+++ b/frontend/admin/hooks/useLamduanFlowers.ts
@@ -34,10 +34,6 @@ export function useLamduanFlowers() {
 
             if (res.statusCode === 200) {
                 setLamduanFlowers((prev) => prev.filter((s) => s._id !== id));
-                addToast({
-                    title: 'Lamduan Flowers deleted successfully!',
-                    color: 'success',
-                });
             } else {
               throw new Error(res.message || 'Failed to delete lamduan flowers.');
             }


### PR DESCRIPTION
ดัก Error ของ User และ Lamduan Flowers

**ปัญหาก่อนแก้** : 
- หลังจากที่ User ส่งดอกลำดวนเข้าระบบ หากมีการลบ User ในหน้า Users Management ข้อมูลดอกลำดวนของ User นั้นจะยังคงอยู่ เมื่อเข้าไปที่หน้า Lamduan Flowers จะเกิด Error ทันที เนื่องจากระบบไม่สามารถหา User ที่ถูกลบได้ ตัวอย่างเห็นภาพ : User 6731503119 เคยส่งดอกลำดวนเข้าระบบ แล้วถูกลบออกจาก Users Management เมื่อกลับไปที่หน้า Lamduan Flowers จะพบ Error เพราะหา User ไม่เจอ

**ปัญหาหลังแก้** : 
- เมื่อมีการลบ User ที่เคยส่งดอกลำดวน ระบบจะลบข้อมูลดอกลำดวนของ User นั้นไปด้วย ตัวอย่างเห็นภาพ : User 6731503119 เคยส่งดอกลำดวนไว้ หากลบ User นี้ ข้อมูลดอกลำดวนของuserนั้นจะถูกลบโดยอัตโนมัติ

(ฟังก์ชั่นเพิ่มเติม)
-เปลี่ยนข้อความแจ้งเตือน (Toast) ตอนลบดอกลำดวน จาก "Lamduan Flowers deleted successfully!" เป็น "Deleted {username} flower"
-ลบ Add Toast ออกจาก deleteLamduanFlowers เพราะตอนลบ User จะเรียก handleDelete ของ Lamduan Flowers อัตโนมัติ ซึ่งอาจทำให้เกิด Toast ซ้ำซ้อนหรือทำให้สับสน เพิ่ม Add Toast เฉพาะที่ปุ่มลบของ Card ดอกลำดวนแทน